### PR TITLE
Improve syntax errors

### DIFF
--- a/src/Uroboro/Error.hs
+++ b/src/Uroboro/Error.hs
@@ -3,17 +3,26 @@ Description : Store and format error messages
 -}
 module Uroboro.Error
     ( Error (MakeError)
+    , Location (MakeLocation)
     ) where
 
 import Data.List (intercalate)
 
-data Error = MakeError FilePath Int Int String
+data Error = MakeError Location String
 
-instance Show Error where
-  show (MakeError name line column message) =
+data Location = MakeLocation FilePath Int Int
+
+instance Show Location where
+  show (MakeLocation name line column) =
     intercalate ":"
       [ name
       , show line
       , show column
+      ]
+
+instance Show Error where
+  show (MakeError location message) =
+    intercalate ":"
+      [ show location
       , " Syntax Error"
       ] ++ (unlines $ map ("  " ++) $ lines $ message)

--- a/src/Uroboro/Error.hs
+++ b/src/Uroboro/Error.hs
@@ -1,0 +1,19 @@
+{-|
+Description : Store and format error messages
+-}
+module Uroboro.Error
+    ( Error (MakeError)
+    ) where
+
+import Data.List (intercalate)
+
+data Error = MakeError FilePath Int Int String
+
+instance Show Error where
+  show (MakeError name line column message) =
+    intercalate ":"
+      [ name
+      , show line
+      , show column
+      , " Syntax Error"
+      ] ++ (unlines $ map ("  " ++) $ lines $ message)

--- a/src/Uroboro/Parser.hs
+++ b/src/Uroboro/Parser.hs
@@ -55,9 +55,13 @@ pexp = choice [des, app, var] <?> "expression"
     app = try $ liftM PApp identifier <*> args pexp
     var = liftM PVar identifier
 
+-- | Use up all input for one parser.
+exactly :: Parser a -> Parser a
+exactly parser = whiteSpace *> parser <* eof
+
 -- |Parse exactly one expression.
 parseExp :: Parser PExp
-parseExp = whiteSpace *> pexp <* eof
+parseExp = exactly pexp
 
 -- |Parse pattern.
 pp :: Parser PP
@@ -75,7 +79,7 @@ pq = choice [des, app] <?> "copattern"
 
 -- |Parse whole file.
 parseDef :: Parser [PT]
-parseDef = whiteSpace *> many (choice [pos, neg, fun]) <* eof
+parseDef = exactly $ many (choice [pos, neg, fun])
   where
     pos = definition "data" PTPos <*> where1 con
     neg = definition "codata" PTNeg <*> where1 des

--- a/src/Uroboro/Parser.hs
+++ b/src/Uroboro/Parser.hs
@@ -5,7 +5,11 @@ Parsec applicative style.
 -}
 module Uroboro.Parser
     (
-      parseDef
+      -- * Parsing Uroboro
+      parseFile
+    , parseExpression
+      -- * Individual parsers
+    , parseDef
     , parseExp
     , Parser
     , pq
@@ -28,6 +32,14 @@ import Uroboro.Tree
     , PTRule(..)
     , Type(..)
     )
+
+-- | Parse whole file.
+parseFile :: FilePath -> String -> Either ParseError [PT]
+parseFile fname input = parse parseDef fname input
+
+-- | Parse expression.
+parseExpression :: FilePath -> String -> Either ParseError PExp
+parseExpression fname input = parse parseExp fname input
 
 -- |Parser without user state.
 type Parser = Parsec String ()

--- a/src/Uroboro/Parser.hs
+++ b/src/Uroboro/Parser.hs
@@ -118,13 +118,18 @@ parseDef = exactly $ many (choice [pos, neg, fun])
     where1 :: Parser a -> Parser [a]
     where1 a = reserved "where" *> many1 a
 
--- | Convert error to custom error type
-convertError :: ParseError -> Error
-convertError err = MakeError name line column messages where
-  pos = errorPos err
+-- | Convert location to custom location type
+convertLocation :: SourcePos -> Location
+convertLocation pos = MakeLocation name line column where
   name = sourceName pos
   line = sourceLine pos
   column = sourceColumn pos
+
+-- | Convert error to custom error type
+convertError :: ParseError -> Error
+convertError err = MakeError location messages where
+  pos = errorPos err
+  location = convertLocation pos
   messages = showErrorMessages
                "or" "unknown parse error" "expecting"
                "unexpected" "end of input"

--- a/src/Uroboro/Parser.hs
+++ b/src/Uroboro/Parser.hs
@@ -19,11 +19,10 @@ import Control.Applicative ((<*), (<*>), (*>))
 import Control.Arrow (left)
 import Control.Monad (liftM)
 
-import Data.List (intercalate)
-
 import Text.Parsec
 import Text.Parsec.Error (errorMessages, showErrorMessages)
 
+import Uroboro.Error
 import Uroboro.Token
 import Uroboro.Tree
     (
@@ -118,18 +117,6 @@ parseDef = exactly $ many (choice [pos, neg, fun])
 
     where1 :: Parser a -> Parser [a]
     where1 a = reserved "where" *> many1 a
-
--- | Custom error type (to modify the Show instance)
-data Error = MakeError FilePath Int Int String
-
-instance Show Error where
-  show (MakeError name line column message) =
-    intercalate ":"
-      [ name
-      , show line
-      , show column
-      , " Syntax Error"
-      ] ++ (unlines $ map ("  " ++) $ lines $ message)
 
 -- | Convert error to custom error type
 convertError :: ParseError -> Error

--- a/uroboro.cabal
+++ b/uroboro.cabal
@@ -26,7 +26,7 @@ source-repository head
   location: git://github.com/tewe/uroboro.git
 
 library
-  exposed-modules:     Uroboro.Language, Uroboro.Parser, Uroboro.Checker, Uroboro.Token, Uroboro.Interpreter, Uroboro.Tree
+  exposed-modules:     Uroboro.Language, Uroboro.Parser, Uroboro.Checker, Uroboro.Token, Uroboro.Interpreter, Uroboro.Tree, Uroboro.Error
   other-modules:       Paths_uroboro
   -- other-extensions:
   build-depends:       base >=4.7 && <4.8, parsec >=3.1 && <3.2


### PR DESCRIPTION
The goal of these commits is to change how the location of a syntax error is printed to make it easier for tools to provide a jump-to-error feature.